### PR TITLE
updated **main.ml** to **example.ml**

### DIFF
--- a/3I - build /README.md
+++ b/3I - build /README.md
@@ -156,9 +156,9 @@ E agora vamos fazer o build desse projeto.
 $ dune build
 ```
 
-Se não houver nenhum erro podemos prosseguir, caso haja, revise os passos anteriores. Agora vamos criar um aquivo **main.ml** na nossa raiz que será nosso arquivo principal e um outro arquivo **dune** na raiz com as diretivas de compilação do mesmo.
+Se não houver nenhum erro podemos prosseguir, caso haja, revise os passos anteriores. Agora vamos criar um aquivo **exemplo.ml** na nossa raiz que será nosso arquivo principal e um outro arquivo **dune** na raiz com as diretivas de compilação do mesmo.
 
-**main.ml**
+**exemplo.ml**
 ```OCaml
 open Math.Multiply
 


### PR DESCRIPTION
using **main.ml** as the name of the root file would cause dune to fail its build 

```
File "dune", line 2, characters 8-15:
2 |   (name exemplo)
            ^^^^^^^
Error: Module "Exemplo" doesn't exist.
```