### PR TITLE
Correções ortográficas

### DIFF
--- a/2_funcoes/README.md
+++ b/2_funcoes/README.md
@@ -84,7 +84,7 @@ Isso é bem parecido com quando fazemos atribuição em OCaml, por exemplo `let 
 Enquando `let f = foo` é um binding estático onde sempre será retornado foo, `let f x = foo` irá sempre recalcular o valor após o `=` isso pode parecer igual agora, mas faz diferença caso o valor foo seja mutável. Nesses casos em que queremos escrever um valor como função e não como atribuição, onde o valor é recomputado a cada chamada e não temos atributos relevantes como x nesse caso a escrevemos em OCaml como `let f () = foo` ou `let f _ = foo` para que o parâmetro seja omitido, mas que a função f seja uma função constante que mapeia qualquer entrada para o valor atual de foo.
 
 Graficamente funções constantes produzem gráficos em linha reta, uma vez em que para todo valor de x o y será c:
-![gráfico da função f de x igual a três](https://github.com/Camilotk/ocaml4noobs/blob/master/2-funcoes/imagens/constante.png)
+![gráfico da função f de x igual a três](https://github.com/Camilotk/ocaml4noobs/blob/master/2_funcoes/imagens/constante.png)
 
 > Observe que nesse caso, diferente da matemática onde trabalhamos com elementos numéricos, tanto faz se f(x) = 2 ou f(x) = "2", ambas funções vão sempre retornar o mesmo valor, idependentemente de serem números, strings ou tipos complexos uma vez em que nossas funções também trabalham com outros tipos. 
 

--- a/3_dados/README.md
+++ b/3_dados/README.md
@@ -286,7 +286,7 @@ Diferente de arrays e listas, não possuímos nenhum índice em tuplas e por tan
 
 1. A primeira é quando temos tuplas com dois elementos, nesse caso podemos utilizar a função **fst** para acessar a primeira posição e a função **snd** para acessar a segunda posição. Observe que se tivermos uma tupla com mais que dois elementos como argumento dessa função isso irá nos retornar um erro.
 
-2. Em todos os casos restatnes, utilizamos **Pattern Matching** para acessar os elemntos da tupla.
+2. Em todos os casos restantes, utilizamos **Pattern Matching** para acessar os elementos da tupla.
 
 ```ocaml
 fst ("ocaml4noobs", 3);;
@@ -330,7 +330,7 @@ Uma vez que declaramos o record de alguma determinada estrutura de valores e cam
 ```
 Observe que não precisamos dizer de qual record esse valor que digitamos no REPL pertence, pois o compilador consegue inferir a partir do número de campos e seus tipos a qual record esse valor pertence.
 
-> Caso os valores de record tenham os mesmos campos e os mesmos tipos é recomendável que estejam separados em **módulos** diferentes, que será o assunto do nosso próximo capítulo. Porém, caso queira apenas testar rapidamente tambpem é possível dar uma dica ao compilador quando temos records iguais em um mesmo espaço de qual utilizando acesso `{pessoa.nome = "Camilo"; idade = 26 }`, mas sempre dê preferência pela separação em módulos em projetos reais, isso vai evitar que alguém tente cortar seus dedos como punição.
+> Caso os valores de record tenham os mesmos campos e os mesmos tipos é recomendável que estejam separados em **módulos** diferentes, que será o assunto do nosso próximo capítulo. Porém, caso queira apenas testar rapidamente também é possível dar uma dica ao compilador quando temos records iguais em um mesmo espaço de qual utilizando acesso `{pessoa.nome = "Camilo"; idade = 26 }`, mas sempre dê preferência pela separação em módulos em projetos reais, isso vai evitar que alguém tente cortar seus dedos como punição.
 
 Quando queremos acessar um valor de um record podemos usar ponto seguido do nome do campo para retornar o valor do mesmo
 ```ocaml

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - [Hello World](./1_introducao#hello-world)
 - [Porque OCaml?](./1_introducao#porque-ocaml)
 	- [Concisa e Declarativa](./1_introducao#concisa-e-declarativa)
-  	- [Lingugens Concisas vs Verbosas](./1_introducao#linguagens-concisas-vs-verbosas)
+  	- [Linguagens Concisas vs Verbosas](./1_introducao#linguagens-concisas-vs-verbosas)
 	- [Menos Erros Acidentais](./1_introducao#menos-erros-acidentais)
 - [Particularidades de OCaml](./1_introducao#particularidades-de-ocaml)
 	- [Inferência de Tipos](./1_introducao#infer%C3%AAncia-de-tipos)


### PR DESCRIPTION
Correções ortográficas no README principal e no README de dados, e correção de imagem quebrada da função constante 